### PR TITLE
Add datasets info

### DIFF
--- a/src/tests/all_datasets_info.h
+++ b/src/tests/all_datasets_info.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "datasets.h"
+
+namespace tests {
+
+static inline const DatasetInfo kWDC_astronomical = {"WDC_astronomical.csv", ',', true};
+static inline const DatasetInfo kWDC_symbols = {"WDC_symbols.csv", ',', true};
+static inline const DatasetInfo kWDC_science = {"WDC_science.csv", ',', true};
+static inline const DatasetInfo kWDC_satellites = {"WDC_satellites.csv", ',', true};
+static inline const DatasetInfo kWDC_appearances = {"WDC_appearances.csv", ',', true};
+static inline const DatasetInfo kWDC_astrology = {"WDC_astrology.csv", ',', true};
+static inline const DatasetInfo kWDC_game = {"WDC_game.csv", ',', true};
+static inline const DatasetInfo kWDC_kepler = {"WDC_kepler.csv", ',', true};
+static inline const DatasetInfo kWDC_planetz = {"WDC_planetz.csv", ',', true};
+static inline const DatasetInfo kWDC_age = {"WDC_age.csv", ',', true};
+static inline const DatasetInfo kTestWide = {"TestWide.csv", ',', true};
+static inline const DatasetInfo kabalone = {"abalone.csv", ',', true};
+static inline const DatasetInfo kiris = {"iris.csv", ',', false};
+static inline const DatasetInfo kadult = {"adult.csv", ';', false};
+static inline const DatasetInfo kbreast_cancer = {"breast_cancer.csv", ',', true};
+static inline const DatasetInfo kCIPublicHighway10k = {"CIPublicHighway10k.csv", ',', true};
+static inline const DatasetInfo kneighbors10k = {"neighbors10k.csv", ',', true};
+static inline const DatasetInfo kneighbors50k = {"neighbors50k.csv", ',', true};
+static inline const DatasetInfo kneighbors100k = {"neighbors100k.csv", ',', true};
+static inline const DatasetInfo kCIPublicHighway700 = {"CIPublicHighway700.csv", ',', true};
+static inline const DatasetInfo kEpicVitals = {"EpicVitals.csv", '|', true};
+static inline const DatasetInfo kEpicMeds = {"EpicMeds.csv", '|', true};
+static inline const DatasetInfo kiowa1kk = {"iowa1kk.csv", ',', true};
+static inline const DatasetInfo kfd_reduced_30 = {"fd-reduced-30.csv", ',', true};
+static inline const DatasetInfo kflight_1k = {"flight_1k.csv", ';', true};
+static inline const DatasetInfo kplista_1k = {"plista_1k.csv", ';', false};
+static inline const DatasetInfo kletter = {"letter.csv", ',', false};
+static inline const DatasetInfo kCIPublicHighway = {"CIPublicHighway.csv", ',', true};
+static inline const DatasetInfo kLegacyPayors = {"LegacyPayors.csv", '|', true};
+
+}  // namespace tests

--- a/src/tests/datasets.h
+++ b/src/tests/datasets.h
@@ -13,6 +13,12 @@ struct Dataset {
     bool has_header;
 };
 
+struct DatasetInfo {
+    std::string name;
+    char separator;
+    bool has_header;
+};
+
 class LightDatasets {
 public:
     static inline const std::array<Dataset, 11> datasets_ = {

--- a/src/tests/datasets.h
+++ b/src/tests/datasets.h
@@ -6,12 +6,7 @@
 
 static const auto test_data_dir = std::filesystem::current_path() / "input_data";
 
-struct Dataset {
-    std::string name;
-    size_t hash;
-    char separator;
-    bool has_header;
-};
+namespace tests {
 
 struct DatasetInfo {
     std::string name;
@@ -19,65 +14,9 @@ struct DatasetInfo {
     bool has_header;
 };
 
-class LightDatasets {
-public:
-    static inline const std::array<Dataset, 11> datasets_ = {
-            {{"CIPublicHighway10k.csv", 33398, ',', true},
-             {"neighbors10k.csv", 43368, ',', true},
-             {"WDC_astronomical.csv", 22281, ',', true},
-             {"WDC_age.csv", 19620, ',', true},
-             {"WDC_appearances.csv", 25827, ',', true},
-             {"WDC_astrology.csv", 40815, ',', true},
-             {"WDC_game.csv", 6418, ',', true},
-             {"WDC_science.csv", 19620, ',', true},
-             {"WDC_symbols.csv", 28289, ',', true},
-             {"breast_cancer.csv", 15121, ',', true},
-             {"WDC_kepler.csv", 63730, ',', true}}};
+/// a pair consisting of a dataset and the expected hash
+using DatasetHashPair = std::pair<DatasetInfo, size_t>;
+/// a pair consisting of a vector of datasets and an expected hash
+using DatasetsHashPair = std::pair<std::vector<DatasetInfo>, size_t>;
 
-    // DEPRECATED -- just use
-    // for (auto dataset : LightDatasets::datasets) { ... }
-    static size_t DatasetQuantity() {
-        return datasets_.size();
-    }
-    static std::string DatasetName(size_t i) {
-        return datasets_[i].name;
-    }
-    static char Separator(size_t i) {
-        return datasets_[i].separator;
-    }
-    static bool HasHeader(size_t i) {
-        return datasets_[i].has_header;
-    }
-    static unsigned int Hash(size_t i) {
-        return datasets_[i].hash;
-    }
-};
-
-class HeavyDatasets {
-public:
-    static inline const std::array<Dataset, 6> datasets_ = {
-            {{"adult.csv", 23075, ';', false},
-             {"CIPublicHighway.csv", 13035, ',', true},
-             {"EpicMeds.csv", 50218, '|', true},
-             {"EpicVitals.csv", 2083, '|', true},
-             {"iowa1kk.csv", 28573, ',', true},
-             {"LegacyPayors.csv", 43612, '|', true}}};
-
-    // DEPRECATED -- just use
-    // for (auto dataset : HeavyDatasets::datasets) { ... }
-    static size_t DatasetQuantity() {
-        return datasets_.size();
-    }
-    static std::string DatasetName(size_t i) {
-        return datasets_[i].name;
-    }
-    static char Separator(size_t i) {
-        return datasets_[i].separator;
-    }
-    static bool HasHeader(size_t i) {
-        return datasets_[i].has_header;
-    }
-    static unsigned int Hash(size_t i) {
-        return datasets_[i].hash;
-    }
-};
+}  // namespace tests

--- a/src/tests/test_fd_mine.cpp
+++ b/src/tests/test_fd_mine.cpp
@@ -14,6 +14,7 @@
 #include "config/names.h"
 #include "datasets.h"
 #include "model/table/relational_schema.h"
+#include "test_fd_util.h"
 
 using ::testing::ContainerEq, ::testing::Eq;
 
@@ -42,7 +43,7 @@ std::unique_ptr<FDAlgorithm> CreateFD_MineAlgorithmInstance(std::string const& p
     return algos::CreateAndLoadAlgorithm<Fd_mine>(FD_MineGetParamMap(path, separator, has_header));
 }
 
-class AlgorithmTest : public LightDatasets, public HeavyDatasets, public ::testing::Test {};
+using FDMineAlgorithmTest = AlgorithmTest<Fd_mine>;
 
 std::vector<unsigned int> FD_MineBitsetToIndexVector(boost::dynamic_bitset<> const& bitset) {
     std::vector<unsigned int> res;
@@ -148,13 +149,13 @@ void MinimizeFDs(std::list<FD>& fd_collection) {
     }
 }
 
-TEST_F(AlgorithmTest, FD_Mine_ReturnsSameAsPyro) {
+TEST_F(FDMineAlgorithmTest, FD_Mine_ReturnsSameAsPyro) {
     namespace onam = config::names;
 
     try {
-        for (Dataset const& dataset : LightDatasets::datasets_) {
+        for (auto const& [dataset, hash] : FDMineAlgorithmTest::light_datasets_) {
             // TODO: change this hotfix
-            if (dataset.name == "breast_cancer.csv") {
+            if (dataset.name == tests::kbreast_cancer.name) {
                 continue;
             }
             auto path = test_data_dir / dataset.name;

--- a/src/tests/test_fd_util.h
+++ b/src/tests/test_fd_util.h
@@ -6,6 +6,7 @@
 
 #include "algorithms/algo_factory.h"
 #include "algorithms/fd/fd_algorithm.h"
+#include "all_datasets_info.h"
 #include "config/error/type.h"
 #include "config/names.h"
 #include "datasets.h"
@@ -38,10 +39,32 @@ protected:
         };
     }
 
+public:
     static std::unique_ptr<algos::FDAlgorithm> CreateAlgorithmInstance(const std::string& filename,
                                                                        char separator = ',',
                                                                        bool has_header = true) {
         return algos::CreateAndLoadAlgorithm<T>(
                 GetParamMap(test_data_dir / filename, separator, has_header));
     }
+
+    static inline const std::vector<tests::DatasetHashPair> light_datasets_ = {
+            {{tests::kCIPublicHighway10k, 33398},
+             {tests::kneighbors10k, 43368},
+             {tests::kWDC_astronomical, 22281},
+             {tests::kWDC_age, 19620},
+             {tests::kWDC_appearances, 25827},
+             {tests::kWDC_astrology, 40815},
+             {tests::kWDC_game, 6418},
+             {tests::kWDC_science, 19620},
+             {tests::kWDC_symbols, 28289},
+             {tests::kbreast_cancer, 15121},
+             {tests::kWDC_kepler, 63730}}};
+
+    static inline const std::vector<tests::DatasetHashPair> heavy_datasets_ = {
+            {{tests::kadult, 23075},
+             {tests::kCIPublicHighway, 13035},
+             {tests::kEpicMeds, 50218},
+             {tests::kEpicVitals, 2083},
+             {tests::kiowa1kk, 28573},
+             {tests::kLegacyPayors, 43612}}};
 };

--- a/src/tests/test_ucc_algorithms.cpp
+++ b/src/tests/test_ucc_algorithms.cpp
@@ -10,6 +10,7 @@
 #include "algorithms/ucc/hyucc/hyucc.h"
 #include "algorithms/ucc/ucc.h"
 #include "algorithms/ucc/ucc_algorithm.h"
+#include "all_datasets_info.h"
 #include "config/thread_number/type.h"
 #include "datasets.h"
 
@@ -53,42 +54,42 @@ public:
                 GetParamMap(test_data_dir / filename, separator, has_header));
     }
 
-    static inline const std::vector<Dataset> light_datasets_ = {
-        {"WDC_astronomical.csv", 2089541732445U, ',', true},
-        {"WDC_symbols.csv", 1, ',', true},
-        {"WDC_science.csv", 2658842082150U, ',', true},
-        {"WDC_satellites.csv", 5208443370856032U, ',', true},
-        {"WDC_appearances.csv", 82369238361U, ',', true},
-        {"WDC_astrology.csv", 79554241843163108U, ',', true},
-        {"WDC_game.csv", 2555214540772530U, ',', true},
-        {"WDC_kepler.csv", 82426217315737U, ',', true},
-        {"WDC_planetz.csv", 2555214540772530U, ',', true},
-        {"WDC_age.csv", 2658842082150U, ',', true},
-        {"TestWide.csv", 2555250373874U, ',', true},
-        {"abalone.csv", 16581571148699134255U, ',', true},
-        {"iris.csv", 1, ',', false},
-        {"adult.csv", 1, ';', false},
-        {"breast_cancer.csv", 16854900230774656828U, ',', true},
+    static inline const std::vector<DatasetHashPair> light_datasets_ = {
+        {kWDC_astronomical, 2089541732445U},
+        {kWDC_symbols, 1},
+        {kWDC_science, 2658842082150U},
+        {kWDC_satellites, 5208443370856032U},
+        {kWDC_appearances, 82369238361U},
+        {kWDC_astrology, 79554241843163108U},
+        {kWDC_game, 2555214540772530U},
+        {kWDC_kepler, 82426217315737U},
+        {kWDC_planetz, 2555214540772530U},
+        {kWDC_age, 2658842082150U},
+        {kTestWide, 2555250373874U},
+        {kabalone, 16581571148699134255U},
+        {kiris, 1},
+        {kadult, 1},
+        {kbreast_cancer, 16854900230774656828U},
         // Possibly heavy datasets, if another less efficient algorithm than HyUCC is not
         // able to process these move them to heavy_datasets_
-        {"neighbors10k.csv", 170971924188219U, ',', true},
+        {kneighbors10k, 170971924188219U},
 #if 0
-        {"neighbors50k.csv", 1, ',', true},
+        {kneighbors50k, 1},
 #endif
-        {"neighbors100k.csv", 170971924188219U, ',', true},
-        {"CIPublicHighway10k.csv", 82369238361U, ',', true},
-        {"CIPublicHighway700.csv", 82369238361U, ',', true},
+        {kneighbors100k, 170971924188219U},
+        {kCIPublicHighway10k, 82369238361U},
+        {kCIPublicHighway700, 82369238361U},
     };
 
-    static inline const std::vector<Dataset> heavy_datasets_ = {
-        {"EpicVitals.csv", 1, '|', true},
-        {"EpicMeds.csv", 59037771758954037U, '|', true},
-        {"iowa1kk.csv", 2654435863U, ',', true},
+    static inline const std::vector<DatasetHashPair> heavy_datasets_ = {
+        {kEpicVitals, 1},
+        {kEpicMeds, 59037771758954037U},
+        {kiowa1kk, 2654435863U},
 #if 0
-        {"fd-reduced-30.csv", 275990379954778425U, ',', true},
-        {"flight_1k.csv", 2512091017708538662U, ';', true},
-        {"plista_1k.csv", 1, ';', false},
-        {"letter.csv", 1, ',', false},
+        {kfd_reduced_30, 275990379954778425U},
+        {kflight_1k, 2512091017708538662U},
+        {kplista_1k, 1},
+        {kletter, 1},
 #endif
     };
 };
@@ -120,8 +121,8 @@ std::size_t Hash(std::vector<std::vector<unsigned>> const& vec) {
 }
 
 template <typename T>
-void PerformConsistentHashTestOn(std::vector<Dataset> const& datasets) {
-    for (Dataset const& dataset : datasets) {
+void PerformConsistentHashTestOn(std::vector<DatasetHashPair> const& datasets) {
+    for (auto const& [dataset, hash] : datasets) {
         try {
             auto ucc_algo =
                     T::CreateAlgorithmInstance(dataset.name, dataset.separator, dataset.has_header);
@@ -133,7 +134,7 @@ void PerformConsistentHashTestOn(std::vector<Dataset> const& datasets) {
             std::transform(actual_list.begin(), actual_list.end(), std::back_inserter(actual),
                            [](Vertical const& v) { return v.GetColumnIndicesAsVector(); });
             std::sort(actual.begin(), actual.end());
-            EXPECT_EQ(Hash(actual), dataset.hash) << "Wrong hash on dataset " << dataset.name;
+            EXPECT_EQ(Hash(actual), hash) << "Wrong hash on dataset " << dataset.name;
         } catch (std::exception const& e) {
             std::cout << "An exception with message: " << e.what() << "\n\tis thrown on dataset "
                       << dataset.name << '\n';


### PR DESCRIPTION
In this pull request, a single file has been added, which should contain information about all datasets in order to avoid duplication of information.
It is important to note that this pull request does not aim to unify all test files, but is limited to only a part of the tests.
In the future it can also be used in other tests.