### PR TITLE
Implement `INDVerifier` and add error threshold field to the `IND` class.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -68,7 +68,7 @@ fi
 if [[ ! -d "better-enums" ]] ; then
   git clone https://github.com/aantron/better-enums.git --branch 0.11.3 --depth 1
 fi
-if [[ ! -d "pybind" ]] ; then
+if [[ ! -d "pybind11" ]] ; then
   git clone https://github.com/pybind/pybind11.git --branch v2.13.4 --depth 1
 fi
 if [[ ! -d "emhash" ]] ; then

--- a/src/core/algorithms/ind/ind.cpp
+++ b/src/core/algorithms/ind/ind.cpp
@@ -24,6 +24,10 @@ std::string IND::ToShortString() const {
 
     std::stringstream ss;
     ss << cc_to_short_string(GetLhs()) << " -> " << cc_to_short_string(GetRhs());
+    if (GetError() != 0.0) {
+        ss << " with error threshold = " << GetError();
+    }
+
     return ss.str();
 }
 
@@ -45,6 +49,10 @@ std::string IND::ToLongString() const {
 
     std::stringstream ss;
     ss << cc_to_long_string(GetLhs()) << " -> " << cc_to_long_string(GetRhs());
+    if (GetError() != 0.0) {
+        ss << " with error threshold = " << GetError();
+    }
+
     return ss.str();
 }
 

--- a/src/core/algorithms/ind/ind.h
+++ b/src/core/algorithms/ind/ind.h
@@ -3,24 +3,31 @@
 #include <memory>
 #include <string>
 
+#include "config/error/type.h"
 #include "model/table/column_combination.h"
 #include "model/table/relational_schema.h"
 #include "model/table/vertical.h"
 
 namespace model {
 
-// Inclusion dependency is a relation between attributes of tables
-// that indicates possible Primary Key–Foreign Key references.
+///
+/// Inclusion dependency is a relation between attributes of tables
+/// that indicates possible Primary Key–Foreign Key references.
+///
+/// \note It also stores an error threshold in the interval [0, 1], where
+///       lower value indicate a higher degree of IND satisfaction.
+///
 class IND {
 private:
     std::shared_ptr<ColumnCombination> lhs_;
     std::shared_ptr<ColumnCombination> rhs_;
     std::shared_ptr<std::vector<RelationalSchema>> schemas_;
+    config::ErrorType error_;
 
 public:
     IND(std::shared_ptr<ColumnCombination> lhs, std::shared_ptr<ColumnCombination> rhs,
-        std::shared_ptr<std::vector<RelationalSchema>> schemas)
-        : lhs_(std::move(lhs)), rhs_(std::move(rhs)), schemas_(std::move(schemas)) {}
+        std::shared_ptr<std::vector<RelationalSchema>> schemas, config::ErrorType error = 0.0)
+        : lhs_(std::move(lhs)), rhs_(std::move(rhs)), schemas_(std::move(schemas)), error_(error) {}
 
     ColumnCombination const& GetLhs() const {
         return *lhs_;
@@ -28,6 +35,17 @@ public:
 
     ColumnCombination const& GetRhs() const {
         return *rhs_;
+    }
+
+    ///
+    /// get error threshold
+    ///
+    /// \note Informally, this is the proportion of values in the dataset stream
+    ///       that would need to be removed (independently of their occurrences)
+    ///       in order to produce a modified dataset stream where the IND holds.
+    ///
+    config::ErrorType GetError() const {
+        return error_;
     }
 
     bool StartsWith(IND const& other) const noexcept {

--- a/src/core/algorithms/ind/ind_algorithm.h
+++ b/src/core/algorithms/ind/ind_algorithm.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "algorithms/algorithm.h"
+#include "error/type.h"
 #include "ind.h"
 #include "model/table/relational_schema.h"
 #include "tabular_data/input_tables_type.h"
@@ -39,13 +40,15 @@ protected:
     explicit INDAlgorithm(std::vector<std::string_view> phase_names);
 
     virtual void RegisterIND(std::shared_ptr<model::ColumnCombination> lhs,
-                             std::shared_ptr<model::ColumnCombination> rhs) {
-        ind_collection_.Register(std::move(lhs), std::move(rhs), schemas_);
+                             std::shared_ptr<model::ColumnCombination> rhs,
+                             config::ErrorType error = 0.0) {
+        ind_collection_.Register(std::move(lhs), std::move(rhs), schemas_, error);
     }
 
-    void RegisterIND(model::ColumnCombination lhs, model::ColumnCombination rhs) {
+    void RegisterIND(model::ColumnCombination lhs, model::ColumnCombination rhs,
+                     config::ErrorType error = 0.0) {
         RegisterIND(std::make_shared<model::ColumnCombination>(std::move(lhs)),
-                    std::make_shared<model::ColumnCombination>(std::move(rhs)));
+                    std::make_shared<model::ColumnCombination>(std::move(rhs)), error);
     }
 
     virtual void RegisterIND(IND ind) {

--- a/src/core/algorithms/ind/mind/mind.cpp
+++ b/src/core/algorithms/ind/mind/mind.cpp
@@ -12,6 +12,7 @@
 #include "config/error/option.h"
 #include "config/names_and_descriptions.h"
 #include "dataset_stream_projection.h"
+#include "error/type.h"
 #include "ind/ind_algorithm.h"
 #include "max_arity/option.h"
 #include "table/column_combination.h"
@@ -156,7 +157,7 @@ HashSet CreateHashSet(DatasetStreamFixedProjection&& stream) {
 }  // namespace
 }  // namespace mind
 
-bool Mind::TestCandidate(RawIND const& raw_ind) {
+std::pair<bool, std::optional<config::ErrorType>> Mind::TestCandidate(RawIND const& raw_ind) {
     using namespace mind;
 
     auto const create_projected_stream = [&](model::ColumnCombination const& cc) {
@@ -170,9 +171,9 @@ bool Mind::TestCandidate(RawIND const& raw_ind) {
     if (max_ind_error_ == 0) {
         DatasetStreamFixedProjection r_stream = create_projected_stream(raw_ind.lhs);
         while (r_stream.HasNextRow()) {
-            if (!s_hash_set.contains(r_stream.GetNextRow())) return false;
+            if (!s_hash_set.contains(r_stream.GetNextRow())) return {false, std::nullopt};
         }
-        return true;
+        return {true, config::ErrorType{0.0}};
     }
 
     HashSet const r_hash_set{CreateHashSet(create_projected_stream(raw_ind.lhs))};
@@ -186,13 +187,16 @@ bool Mind::TestCandidate(RawIND const& raw_ind) {
             if (disqualify_row_count == disqualify_row_limit) {
                 assert(static_cast<config::ErrorType>(disqualify_row_count) / r_cardinality >
                        max_ind_error_);
-                return false;
+                return {false, std::nullopt};
             }
         }
     }
 
     auto const error = static_cast<config::ErrorType>(disqualify_row_count) / r_cardinality;
-    return error <= max_ind_error_;
+    if (error <= max_ind_error_)
+        return {true, error};
+    else
+        return {false, std::nullopt};
 }
 
 /*
@@ -246,8 +250,9 @@ void Mind::MineNaryINDs() {
         prev_it = std::prev(INDList().end()); /*< last element of the previous lattice level */
         prev_raw_inds.clear();
         for (RawIND const& candidate : candidates) {
-            if (TestCandidate(candidate)) {
-                RegisterIND(candidate.lhs, candidate.rhs);
+            auto const& [is_valid, error_opt] = TestCandidate(candidate);
+            if (is_valid) {
+                RegisterIND(candidate.lhs, candidate.rhs, error_opt.value());
                 prev_raw_inds.insert(candidate);
             }
         }

--- a/src/core/algorithms/ind/mind/mind.h
+++ b/src/core/algorithms/ind/mind/mind.h
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 
 #include "algorithms/ind/ind_algorithm.h"
 #include "config/error/type.h"
@@ -44,7 +45,13 @@ private:
     bool SetExternalOption(std::string_view option_name, boost::any const& value) override;
     void LoadINDAlgorithmDataInternal() override;
 
-    bool TestCandidate(RawIND const& raw_ind);
+    ///
+    /// Test a given IND candidate to determine if it should be registered.
+    ///
+    /// \return `false` with `std::nullopt` if the candidate should not be registered,
+    ///         otherwise return `true` along with the associated error threshold.
+    ///
+    std::pair<bool, std::optional<config::ErrorType>> TestCandidate(RawIND const& raw_ind);
 
     void MineUnaryINDs();
     void MineNaryINDs();

--- a/src/core/algorithms/ind/spider/attribute.cpp
+++ b/src/core/algorithms/ind/spider/attribute.cpp
@@ -9,11 +9,9 @@ namespace algos::spider {
 
 std::vector<AttributeIndex> AINDAttribute::GetRefIds(config::ErrorType max_error) const {
     std::vector<AttributeIndex> refs;
-    auto const dep_count = static_cast<double>(occurrences_[id_]);
     for (size_t ref_id = 0; ref_id != occurrences_.size(); ++ref_id) {
         if (id_ == ref_id) continue;
-        config::ErrorType const error = 1 - occurrences_[ref_id] / dep_count;
-        if (error <= max_error) {
+        if (GetError(ref_id) <= max_error) {
             refs.push_back(ref_id);
         }
     }

--- a/src/core/algorithms/ind/spider/attribute.h
+++ b/src/core/algorithms/ind/spider/attribute.h
@@ -84,6 +84,12 @@ public:
 
     /// get referenced attribute indices
     std::vector<AttributeIndex> GetRefIds(config::ErrorType max_error) const;
+
+    /// get error threshold
+    config::ErrorType GetError(AttributeIndex ref_id) const {
+        auto const dep_count = static_cast<config::ErrorType>(occurrences_[id_]);
+        return 1 - occurrences_[ref_id] / dep_count;
+    }
 };
 
 /// attribute for IND

--- a/src/core/algorithms/ind/spider/spider.cpp
+++ b/src/core/algorithms/ind/spider/spider.cpp
@@ -116,7 +116,7 @@ void Spider::MineAINDs() {
     std::vector const attrs = GetProcessedAttributes<AINDAttribute>(domains_, is_null_equal_null_);
     for (auto const& dep : attrs) {
         for (AttributeIndex ref_id : dep.GetRefIds(max_ind_error_)) {
-            RegisterIND(dep.ToCC(), attrs[ref_id].ToCC());
+            RegisterIND(dep.ToCC(), attrs[ref_id].ToCC(), dep.GetError(ref_id));
         }
     }
 }

--- a/src/python_bindings/ind/bind_ind.cpp
+++ b/src/python_bindings/ind/bind_ind.cpp
@@ -21,7 +21,8 @@ void BindInd(py::module_& main_module) {
             .def("to_short_string", &IND::ToShortString)
             .def("to_long_string", &IND::ToLongString)
             .def("get_lhs", &IND::GetLhs)
-            .def("get_rhs", &IND::GetRhs);
+            .def("get_rhs", &IND::GetRhs)
+            .def("get_error", &IND::GetError);
 
     static constexpr auto kSpiderName = "Spider";
     static constexpr auto kMindName = "Mind";

--- a/src/tests/test_ind_algorithms.cpp
+++ b/src/tests/test_ind_algorithms.cpp
@@ -7,6 +7,7 @@
 #include "config/names.h"
 #include "config/thread_number/type.h"
 #include "csv_config_util.h"
+#include "error/type.h"
 #include "max_arity/type.h"
 #include "test_hash_util.h"
 #include "test_ind_util.h"
@@ -43,7 +44,15 @@ protected:
             try {
                 auto ind_algo = CreateAlgorithmInstance(csv_configs, test_config);
                 ind_algo->Execute();
-                EXPECT_EQ(HashVec(ToSortedINDTestVec(ind_algo->INDList()), HashPair), hash)
+
+                std::list<model::IND> const& inds = ind_algo->INDList();
+                // in this test we're mining only exact INDs
+                for (auto const& ind : inds) {
+                    EXPECT_EQ(ind.GetError(), config::ErrorType{0.0})
+                            << "Error score mismatch for IND: " << ind.ToShortString();
+                }
+
+                EXPECT_EQ(HashVec(ToSortedINDTestVec(inds), HashPair), hash)
                         << "Wrong hash on datasets " << TableNamesToString(csv_configs);
             } catch (std::exception const& e) {
                 std::cerr << "An exception with message: " << e.what()


### PR DESCRIPTION
Description:
- Add an error threshold field to the `IND` class
- Introduce a field in the `IND` class to store an error threshold that represents the degree of `IND` satisfaction.
- Adjust the registration methods in the approximate `INDAlgorithm`s to provide the error threshold.
